### PR TITLE
Extended hash_table_iter_next function

### DIFF
--- a/src/hash-table.c
+++ b/src/hash-table.c
@@ -440,11 +440,12 @@ int hash_table_iter_has_more(HashTableIterator *iterator)
 	return iterator->next_entry != NULL;
 }
 
-HashTableValue hash_table_iter_next(HashTableIterator *iterator)
+HashTableValue hash_table_iter_next(HashTableIterator *iterator, int flag)
 {
 	HashTableEntry *current_entry;
 	HashTable *hash_table;
 	HashTableValue result;
+	void* res[2];
 	unsigned int chain;
 
 	hash_table = iterator->hash_table;
@@ -458,7 +459,23 @@ HashTableValue hash_table_iter_next(HashTableIterator *iterator)
 	/* Result is immediately available */
 
 	current_entry = iterator->next_entry;
-	result = current_entry->value;
+
+	switch (flag) {
+	case VALUE:
+		result = current_entry->value;
+		break;
+	case KEY:
+		result = current_entry->key;
+		break;
+	case KEY_VALUE:
+		res[0] = current_entry->key;
+		res[1] = current_entry->value;
+		result = res;
+		break;
+	default:
+		result = current_entry->value;
+		break;
+	}
 
 	/* Find the next entry */
 

--- a/src/hash-table.c
+++ b/src/hash-table.c
@@ -440,12 +440,27 @@ int hash_table_iter_has_more(HashTableIterator *iterator)
 	return iterator->next_entry != NULL;
 }
 
-HashTableValue hash_table_iter_next(HashTableIterator *iterator, int flag)
+HashTableValue hash_table_value(HashTableIterator *iterator) {
+	HashTableValue result = HASH_TABLE_NULL;
+
+	/* Iterator has handle on a valid HashTable? */
+	if (iterator == NULL || iterator->hash_table == NULL) {
+		return HASH_TABLE_NULL;
+	}
+
+	unsigned int cursor = (iterator->next_chain - 1);
+	HashTableEntry* current_handle = iterator->hash_table->table[cursor];
+	result = current_handle->key;
+
+	return result;
+}
+
+HashTableValue hash_table_iter_next(HashTableIterator *iterator)
 {
 	HashTableEntry *current_entry;
 	HashTable *hash_table;
 	HashTableValue result;
-	void* res[2];
+
 	unsigned int chain;
 
 	hash_table = iterator->hash_table;
@@ -459,23 +474,7 @@ HashTableValue hash_table_iter_next(HashTableIterator *iterator, int flag)
 	/* Result is immediately available */
 
 	current_entry = iterator->next_entry;
-
-	switch (flag) {
-	case VALUE:
-		result = current_entry->value;
-		break;
-	case KEY:
-		result = current_entry->key;
-		break;
-	case KEY_VALUE:
-		res[0] = current_entry->key;
-		res[1] = current_entry->value;
-		result = res;
-		break;
-	default:
-		result = current_entry->value;
-		break;
-	}
+	result = current_entry->key;
 
 	/* Find the next entry */
 

--- a/src/hash-table.c
+++ b/src/hash-table.c
@@ -441,7 +441,7 @@ int hash_table_iter_has_more(HashTableIterator *iterator)
 }
 
 HashTableValue hash_table_value(HashTableIterator *iterator) {
-	HashTableValue result = HASH_TABLE_NULL;
+	HashTableEntry* current_handle;
 
 	/* Iterator has handle on a valid HashTable? */
 	if (iterator == NULL || iterator->hash_table == NULL) {
@@ -449,10 +449,13 @@ HashTableValue hash_table_value(HashTableIterator *iterator) {
 	}
 
 	unsigned int cursor = (iterator->next_chain - 1);
-	HashTableEntry* current_handle = iterator->hash_table->table[cursor];
-	result = current_handle->key;
+	current_handle = iterator->hash_table->table[cursor];
 
-	return result;
+	if(current_handle == NULL){
+		return HASH_TABLE_NULL;
+	}
+
+	return current_handle->value;
 }
 
 HashTableValue hash_table_iter_next(HashTableIterator *iterator)

--- a/src/hash-table.c
+++ b/src/hash-table.c
@@ -440,29 +440,11 @@ int hash_table_iter_has_more(HashTableIterator *iterator)
 	return iterator->next_entry != NULL;
 }
 
-HashTableValue hash_table_value(HashTableIterator *iterator) {
-	HashTableEntry* current_handle;
-
-	/* Iterator has handle on a valid HashTable? */
-	if (iterator == NULL || iterator->hash_table == NULL) {
-		return HASH_TABLE_NULL;
-	}
-
-	unsigned int cursor = (iterator->next_chain - 1);
-	current_handle = iterator->hash_table->table[cursor];
-
-	if(current_handle == NULL){
-		return HASH_TABLE_NULL;
-	}
-
-	return current_handle->value;
-}
-
-HashTableValue hash_table_iter_next(HashTableIterator *iterator)
+HashTableKey hash_table_iter_next(HashTableIterator *iterator)
 {
 	HashTableEntry *current_entry;
 	HashTable *hash_table;
-	HashTableValue result;
+	HashTableKey key;
 
 	unsigned int chain;
 
@@ -477,7 +459,7 @@ HashTableValue hash_table_iter_next(HashTableIterator *iterator)
 	/* Result is immediately available */
 
 	current_entry = iterator->next_entry;
-	result = current_entry->key;
+	key = current_entry->key;
 
 	/* Find the next entry */
 
@@ -515,6 +497,6 @@ HashTableValue hash_table_iter_next(HashTableIterator *iterator)
 		iterator->next_chain = chain;
 	}
 
-	return result;
+	return key;
 }
 

--- a/src/hash-table.h
+++ b/src/hash-table.h
@@ -243,18 +243,7 @@ int hash_table_iter_has_more(HashTableIterator *iterator);
  *                            keys to iterate over.
  */
 
-HashTableValue hash_table_iter_next(HashTableIterator *iterator);
-
-/**
- * Using a hash table iterator, retrieve @ref HashTable value
- * held by existing iterator handle.
- *
- * @param iterator            The hash table iterator.
- * @return                    @ref HashTable value currently placed under
- *                            iterator handle, else @ref HASH_TABLE_NULL.
- */
-
-HashTableValue hash_table_value(HashTableIterator *iterator);
+HashTableKey hash_table_iter_next(HashTableIterator *iterator);
 
 #ifdef __cplusplus
 }

--- a/src/hash-table.h
+++ b/src/hash-table.h
@@ -45,10 +45,6 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef ALGORITHM_HASH_TABLE_H
 #define ALGORITHM_HASH_TABLE_H
 
-#define KEY         1
-#define VALUE       2
-#define KEY_VALUE   3
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -242,16 +238,23 @@ int hash_table_iter_has_more(HashTableIterator *iterator);
  * Using a hash table iterator, retrieve the next key.
  *
  * @param iterator            The hash table iterator.
- * @param flag                Flag to determine whether the return value should
- *                            either be the Key, Value or Both KeyValue held in
- *                            array[2] where array[0] is Key and array[1] is value.
- *
  * @return                    The next key from the hash table, or
  *                            @ref HASH_TABLE_NULL if there are no more
  *                            keys to iterate over.
  */
 
-HashTableValue hash_table_iter_next(HashTableIterator *iterator, int flag);
+HashTableValue hash_table_iter_next(HashTableIterator *iterator);
+
+/**
+ * Using a hash table iterator, retrieve @ref HashTable value
+ * held by existing iterator handle.
+ *
+ * @param iterator            The hash table iterator.
+ * @return                    @ref HashTable value currently placed under
+ *                            iterator handle, else @ref HASH_TABLE_NULL.
+ */
+
+HashTableValue hash_table_value(HashTableIterator *iterator);
 
 #ifdef __cplusplus
 }

--- a/src/hash-table.h
+++ b/src/hash-table.h
@@ -45,6 +45,10 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef ALGORITHM_HASH_TABLE_H
 #define ALGORITHM_HASH_TABLE_H
 
+#define KEY         1
+#define VALUE       2
+#define KEY_VALUE   3
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -238,12 +242,16 @@ int hash_table_iter_has_more(HashTableIterator *iterator);
  * Using a hash table iterator, retrieve the next key.
  *
  * @param iterator            The hash table iterator.
+ * @param flag                Flag to determine whether the return value should
+ *                            either be the Key, Value or Both KeyValue held in
+ *                            array[2] where array[0] is Key and array[1] is value.
+ *
  * @return                    The next key from the hash table, or
  *                            @ref HASH_TABLE_NULL if there are no more
  *                            keys to iterate over.
  */
 
-HashTableValue hash_table_iter_next(HashTableIterator *iterator);
+HashTableValue hash_table_iter_next(HashTableIterator *iterator, int flag);
 
 #ifdef __cplusplus
 }

--- a/test/test-hash-table.c
+++ b/test/test-hash-table.c
@@ -428,7 +428,7 @@ void test_hash_table_out_of_memory(void)
 	hash_table_free(hash_table);
 }
 
-void test_hash_iterator_KeyValue_pair() {
+void test_hash_iterator_key_value_pair() {
 
 	HashTable *hash_table;
 	HashTableIterator iterator;
@@ -443,7 +443,8 @@ void test_hash_iterator_KeyValue_pair() {
 
 	while (hash_table_iter_has_more(&iterator)) {
 
-		// Retrieve both Key and Value
+		/* Retrieve both Key and Value */
+
 		HashTableKey key = hash_table_iter_next(&iterator);
 		int* value = (int*) hash_table_lookup(hash_table, key);
 
@@ -461,7 +462,7 @@ static UnitTestFunction tests[] = {
 	test_hash_table_iterating_remove,
 	test_hash_table_free_functions,
 	test_hash_table_out_of_memory,
-	test_hash_iterator_KeyValue_pair,
+	test_hash_iterator_key_value_pair,
 	NULL
 };
 

--- a/test/test-hash-table.c
+++ b/test/test-hash-table.c
@@ -202,6 +202,7 @@ void test_hash_table_iterating(void)
 	assert(count == NUM_TEST_VALUES);
 
 	/* Test iter_next after iteration has completed. */
+
 	assert(hash_table_iter_next(&iterator) == HASH_TABLE_NULL);
 
 	hash_table_free(hash_table);
@@ -431,9 +432,6 @@ void test_hash_iterator_KeyValue_pair() {
 
 	HashTable *hash_table;
 	HashTableIterator iterator;
-	int* key;
-	int* value;
-
 	hash_table = hash_table_new(int_hash, int_equal);
 
 	/* Add some values */
@@ -446,10 +444,8 @@ void test_hash_iterator_KeyValue_pair() {
 	while (hash_table_iter_has_more(&iterator)) {
 
 		// Retrieve both Key and Value
-		key = (int*) hash_table_iter_next(&iterator);
-		value = (int*) hash_table_value(&iterator);
-
-		assert(*key == *value);
+		int* key = (int*) hash_table_iter_next(&iterator);
+		int* value = (int*) hash_table_value(&iterator);
 	}
 
 	hash_table_free(hash_table);

--- a/test/test-hash-table.c
+++ b/test/test-hash-table.c
@@ -433,7 +433,6 @@ void test_hash_iterator_KeyValue_pair() {
 	HashTableIterator iterator;
 	int* key;
 	int* value;
-	int* l_value;
 
 	hash_table = hash_table_new(int_hash, int_equal);
 
@@ -450,9 +449,7 @@ void test_hash_iterator_KeyValue_pair() {
 		key = (int*) hash_table_iter_next(&iterator);
 		value = (int*) hash_table_value(&iterator);
 
-		l_value = hash_table_lookup(hash_table, key);
 		assert(*key == *value);
-		assert(*value == *l_value);
 	}
 
 	hash_table_free(hash_table);

--- a/test/test-hash-table.c
+++ b/test/test-hash-table.c
@@ -444,8 +444,10 @@ void test_hash_iterator_KeyValue_pair() {
 	while (hash_table_iter_has_more(&iterator)) {
 
 		// Retrieve both Key and Value
-		int* key = (int*) hash_table_iter_next(&iterator);
-		int* value = (int*) hash_table_value(&iterator);
+		HashTableKey key = hash_table_iter_next(&iterator);
+		int* value = (int*) hash_table_lookup(hash_table, key);
+
+		assert((int* ) key == (int* )value);
 	}
 
 	hash_table_free(hash_table);

--- a/test/test-hash-table.c
+++ b/test/test-hash-table.c
@@ -194,7 +194,7 @@ void test_hash_table_iterating(void)
 	hash_table_iterate(hash_table, &iterator);
 
 	while (hash_table_iter_has_more(&iterator)) {
-		hash_table_iter_next(&iterator, VALUE);
+		hash_table_iter_next(&iterator);
 
 		++count;
 	}
@@ -202,8 +202,7 @@ void test_hash_table_iterating(void)
 	assert(count == NUM_TEST_VALUES);
 
 	/* Test iter_next after iteration has completed. */
-	assert(hash_table_iter_next(&iterator, KEY) == HASH_TABLE_NULL);
-	assert(hash_table_iter_next(&iterator, VALUE) == HASH_TABLE_NULL);
+	assert(hash_table_iter_next(&iterator) == HASH_TABLE_NULL);
 
 	hash_table_free(hash_table);
 
@@ -245,7 +244,7 @@ void test_hash_table_iterating_remove(void)
 
 		/* Read the next value */
 
-		val = hash_table_iter_next(&iterator, VALUE);
+		val = hash_table_iter_next(&iterator);
 
 		/* Remove every hundredth entry */
 
@@ -428,11 +427,13 @@ void test_hash_table_out_of_memory(void)
 	hash_table_free(hash_table);
 }
 
-void test_hash_iterator_returning_KeyValue_pair(){
+void test_hash_iterator_KeyValue_pair() {
 
 	HashTable *hash_table;
 	HashTableIterator iterator;
-	int** kv_pair;
+	int* key;
+	int* value;
+	int* l_value;
 
 	hash_table = hash_table_new(int_hash, int_equal);
 
@@ -446,10 +447,14 @@ void test_hash_iterator_returning_KeyValue_pair(){
 	while (hash_table_iter_has_more(&iterator)) {
 
 		// Retrieve both Key and Value
-		kv_pair = (int**) hash_table_iter_next(&iterator, KEY_VALUE);
+		key = (int*) hash_table_iter_next(&iterator);
+		value = (int*) hash_table_value(&iterator);
 
-		assert(*((int*)kv_pair[0]) == *((int*)kv_pair[1]));
+		l_value = hash_table_lookup(hash_table, key);
+		assert(*key == *value);
+		assert(*value == *l_value);
 	}
+
 	hash_table_free(hash_table);
 }
 
@@ -461,7 +466,7 @@ static UnitTestFunction tests[] = {
 	test_hash_table_iterating_remove,
 	test_hash_table_free_functions,
 	test_hash_table_out_of_memory,
-	test_hash_iterator_returning_KeyValue_pair,
+	test_hash_iterator_KeyValue_pair,
 	NULL
 };
 

--- a/test/test-hash-table.c
+++ b/test/test-hash-table.c
@@ -194,7 +194,7 @@ void test_hash_table_iterating(void)
 	hash_table_iterate(hash_table, &iterator);
 
 	while (hash_table_iter_has_more(&iterator)) {
-		hash_table_iter_next(&iterator);
+		hash_table_iter_next(&iterator, VALUE);
 
 		++count;
 	}
@@ -202,8 +202,8 @@ void test_hash_table_iterating(void)
 	assert(count == NUM_TEST_VALUES);
 
 	/* Test iter_next after iteration has completed. */
-
-	assert(hash_table_iter_next(&iterator) == HASH_TABLE_NULL);
+	assert(hash_table_iter_next(&iterator, KEY) == HASH_TABLE_NULL);
+	assert(hash_table_iter_next(&iterator, VALUE) == HASH_TABLE_NULL);
 
 	hash_table_free(hash_table);
 
@@ -245,7 +245,7 @@ void test_hash_table_iterating_remove(void)
 
 		/* Read the next value */
 
-		val = hash_table_iter_next(&iterator);
+		val = hash_table_iter_next(&iterator, VALUE);
 
 		/* Remove every hundredth entry */
 
@@ -428,6 +428,31 @@ void test_hash_table_out_of_memory(void)
 	hash_table_free(hash_table);
 }
 
+void test_hash_iterator_returning_KeyValue_pair(){
+
+	HashTable *hash_table;
+	HashTableIterator iterator;
+	int** kv_pair;
+
+	hash_table = hash_table_new(int_hash, int_equal);
+
+	/* Add some values */
+
+	hash_table_insert(hash_table, &value1, &value1);
+	hash_table_insert(hash_table, &value2, &value2);
+
+	hash_table_iterate(hash_table, &iterator);
+
+	while (hash_table_iter_has_more(&iterator)) {
+
+		// Retrieve both Key and Value
+		kv_pair = (int**) hash_table_iter_next(&iterator, KEY_VALUE);
+
+		assert(*((int*)kv_pair[0]) == *((int*)kv_pair[1]));
+	}
+	hash_table_free(hash_table);
+}
+
 static UnitTestFunction tests[] = {
 	test_hash_table_new_free,
 	test_hash_table_insert_lookup,
@@ -436,6 +461,7 @@ static UnitTestFunction tests[] = {
 	test_hash_table_iterating_remove,
 	test_hash_table_free_functions,
 	test_hash_table_out_of_memory,
+	test_hash_iterator_returning_KeyValue_pair,
 	NULL
 };
 


### PR DESCRIPTION
Added a flag to decide **HashTableValue**. 

* Flag VALUE instructs **hash_table_iter_next** to return value.
* Flag KEY instructs **hash_table_iter_next** to return the key.
* Flag KEY_VALUE instructs **hash_table_iter_next** to return both key value pair.

KeyValue Pair is held in array[2] where array[0] is the key and array[1] is the value.