### PR TITLE
Missing rb_tree_subtree_height implementation

### DIFF
--- a/src/rb-tree.c
+++ b/src/rb-tree.c
@@ -456,6 +456,25 @@ RBTreeNode *rb_tree_node_parent(RBTreeNode *node)
 	return node->parent;
 }
 
+int rb_tree_subtree_height(RBTreeNode *node)
+{
+	int left_height;
+	int right_height;
+
+	if (node == NULL) {
+		return 0;
+	}
+
+	left_height = rb_tree_subtree_height(node->children[RB_TREE_NODE_LEFT]);
+	right_height = rb_tree_subtree_height(node->children[RB_TREE_NODE_RIGHT]);
+
+	if (left_height > right_height) {
+		return left_height + 1;
+	} else {
+		return right_height + 1;
+	}
+}
+
 RBTreeKey *rb_tree_to_array(RBTree *tree)
 {
 	/* TODO */


### PR DESCRIPTION
Fixes #33 
## Summary

- Implement `rb_tree_subtree_height` so the symbol declared in `rb-tree.h` is available to consumers.
- Unblocks downstream bindings (Python wrapper) that link against the red-black tree helpers.

## Checklist

- [x] Code is written in C and follows the guidance in `STYLE.md`
- [x] No duplicate implementations of existing data structures or algorithms
- [ ] Public APIs are documented with Doxygen comments
- [x] Comments use full English sentences where clarification is needed
- [ ] Unit tests cover new behaviour (aim for ≥95% coverage; use `configure --enable-coverage` if needed)
- [x] All existing and new tests pass (`make check` or equivalent)

## Additional Notes

- No behaviour changes beyond exposing the helper; downstream consumers should no longer see missing symbol errors.